### PR TITLE
Add meeting scheduling tables, models, and demo seed data

### DIFF
--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+class Meeting extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'dentist_id',
+        'title',
+        'description',
+        'treatment_type',
+        'location',
+        'is_virtual',
+        'video_conference_link',
+        'scheduled_at',
+        'duration_minutes',
+        'status',
+        'follow_up_required',
+        'follow_up_notes',
+        'reminders',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+        'is_virtual' => 'boolean',
+        'follow_up_required' => 'boolean',
+        'reminders' => 'array',
+    ];
+
+    /**
+     * Scope a query to only include meetings scheduled from now on.
+     */
+    public function scopeUpcoming(Builder $query): Builder
+    {
+        return $query->where('scheduled_at', '>=', Carbon::now())->orderBy('scheduled_at');
+    }
+
+    /**
+     * Scope a query to meetings that still require follow-up actions.
+     */
+    public function scopePendingFollowUp(Builder $query): Builder
+    {
+        return $query->where('follow_up_required', true)->whereNull('follow_up_notes');
+    }
+
+    /**
+     * Relationship: dentist responsible for the meeting.
+     */
+    public function dentist(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'dentist_id');
+    }
+
+    /**
+     * Relationship: participants for the meeting.
+     */
+    public function participants(): HasMany
+    {
+        return $this->hasMany(MeetingParticipant::class);
+    }
+
+    /**
+     * Relationship: notes linked to the meeting.
+     */
+    public function notes(): HasMany
+    {
+        return $this->hasMany(MeetingNote::class);
+    }
+
+    /**
+     * Relationship: analytics summary for the meeting.
+     */
+    public function analytics(): HasOne
+    {
+        return $this->hasOne(MeetingAnalytic::class);
+    }
+}

--- a/app/Models/MeetingAnalytic.php
+++ b/app/Models/MeetingAnalytic.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class MeetingAnalytic extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'meeting_id',
+        'total_duration_minutes',
+        'total_participants',
+        'unique_patients',
+        'average_engagement',
+        'metrics',
+        'calculated_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'calculated_at' => 'datetime',
+        'metrics' => 'array',
+        'average_engagement' => 'float',
+    ];
+
+    /**
+     * Scope a query to analytics calculated recently.
+     */
+    public function scopeRecent(Builder $query): Builder
+    {
+        return $query->orderByDesc('calculated_at');
+    }
+
+    /**
+     * Scope analytics that show high engagement.
+     */
+    public function scopeHighEngagement(Builder $query, float $threshold = 85.0): Builder
+    {
+        return $query->where('average_engagement', '>=', $threshold);
+    }
+
+    /**
+     * Relationship: meeting the analytics belong to.
+     */
+    public function meeting(): BelongsTo
+    {
+        return $this->belongsTo(Meeting::class);
+    }
+}

--- a/app/Models/MeetingNote.php
+++ b/app/Models/MeetingNote.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class MeetingNote extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'meeting_id',
+        'author_id',
+        'title',
+        'category',
+        'body',
+        'is_private',
+        'attachments',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_private' => 'boolean',
+        'attachments' => 'array',
+    ];
+
+    /**
+     * Scope a query to only public notes.
+     */
+    public function scopePublic(Builder $query): Builder
+    {
+        return $query->where('is_private', false);
+    }
+
+    /**
+     * Scope notes by category.
+     */
+    public function scopeForCategory(Builder $query, string $category): Builder
+    {
+        return $query->where('category', $category);
+    }
+
+    /**
+     * Relationship: meeting the note belongs to.
+     */
+    public function meeting(): BelongsTo
+    {
+        return $this->belongsTo(Meeting::class);
+    }
+
+    /**
+     * Relationship: author of the note.
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+}

--- a/app/Models/MeetingParticipant.php
+++ b/app/Models/MeetingParticipant.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class MeetingParticipant extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'meeting_id',
+        'user_id',
+        'full_name',
+        'email',
+        'phone_number',
+        'role',
+        'status',
+        'invited_at',
+        'joined_at',
+        'left_at',
+        'metadata',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'invited_at' => 'datetime',
+        'joined_at' => 'datetime',
+        'left_at' => 'datetime',
+        'metadata' => 'array',
+    ];
+
+    /**
+     * Scope a query to filter participants by role.
+     */
+    public function scopeForRole(Builder $query, string $role): Builder
+    {
+        return $query->where('role', $role);
+    }
+
+    /**
+     * Scope a query to confirmed participants.
+     */
+    public function scopeConfirmed(Builder $query): Builder
+    {
+        return $query->where('status', 'confirmed');
+    }
+
+    /**
+     * Relationship: meeting the participant belongs to.
+     */
+    public function meeting(): BelongsTo
+    {
+        return $this->belongsTo(Meeting::class);
+    }
+
+    /**
+     * Relationship: user when participant is registered in the platform.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_09_22_214111_create_meetings_table.php
+++ b/database/migrations/2025_09_22_214111_create_meetings_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meetings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('dentist_id')->constrained('users');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('treatment_type')->nullable();
+            $table->string('location')->nullable();
+            $table->boolean('is_virtual')->default(false);
+            $table->string('video_conference_link')->nullable();
+            $table->timestamp('scheduled_at');
+            $table->unsignedSmallInteger('duration_minutes')->default(30);
+            $table->string('status')->default('scheduled');
+            $table->boolean('follow_up_required')->default(false);
+            $table->text('follow_up_notes')->nullable();
+            $table->json('reminders')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['dentist_id', 'scheduled_at']);
+            $table->index('status');
+            $table->index('scheduled_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meetings');
+    }
+};

--- a/database/migrations/2025_09_22_214113_create_meeting_participants_table.php
+++ b/database/migrations/2025_09_22_214113_create_meeting_participants_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meeting_participants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('meeting_id')->constrained('meetings')->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('full_name');
+            $table->string('email')->nullable();
+            $table->string('phone_number')->nullable();
+            $table->string('role')->default('patient');
+            $table->string('status')->default('invited');
+            $table->timestamp('invited_at')->nullable();
+            $table->timestamp('joined_at')->nullable();
+            $table->timestamp('left_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['meeting_id', 'status']);
+            $table->index(['user_id', 'role']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meeting_participants');
+    }
+};

--- a/database/migrations/2025_09_22_214115_create_meeting_notes_table.php
+++ b/database/migrations/2025_09_22_214115_create_meeting_notes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meeting_notes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('meeting_id')->constrained('meetings')->cascadeOnDelete();
+            $table->foreignId('author_id')->constrained('users');
+            $table->string('title');
+            $table->string('category')->default('general');
+            $table->text('body');
+            $table->boolean('is_private')->default(false);
+            $table->json('attachments')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->index(['meeting_id', 'is_private']);
+            $table->index('author_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meeting_notes');
+    }
+};

--- a/database/migrations/2025_09_22_214116_create_meeting_analytics_table.php
+++ b/database/migrations/2025_09_22_214116_create_meeting_analytics_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meeting_analytics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('meeting_id')->constrained('meetings')->cascadeOnDelete();
+            $table->unsignedInteger('total_duration_minutes')->default(0);
+            $table->unsignedInteger('total_participants')->default(0);
+            $table->unsignedInteger('unique_patients')->default(0);
+            $table->decimal('average_engagement', 5, 2)->default(0);
+            $table->json('metrics')->nullable();
+            $table->timestamp('calculated_at')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->unique('meeting_id');
+            $table->index('calculated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meeting_analytics');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,11 +12,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(MeetingSeeder::class);
     }
 }

--- a/database/seeders/MeetingSeeder.php
+++ b/database/seeders/MeetingSeeder.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Meeting;
+use App\Models\MeetingAnalytic;
+use App\Models\MeetingNote;
+use App\Models\MeetingParticipant;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+class MeetingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $dentists = collect([
+            ['name' => 'Dra. Ana Molina', 'email' => 'ana.molina@dentaldemo.test'],
+            ['name' => 'Dr. Carlos Rivera', 'email' => 'carlos.rivera@dentaldemo.test'],
+        ])->map(fn (array $data) => User::factory()->create($data));
+
+        $patients = collect([
+            ['name' => 'Lucía Fernández', 'email' => 'lucia.fernandez@paciente.test'],
+            ['name' => 'Mario López', 'email' => 'mario.lopez@paciente.test'],
+            ['name' => 'Sofía Herrera', 'email' => 'sofia.herrera@paciente.test'],
+            ['name' => 'Pedro Sánchez', 'email' => 'pedro.sanchez@paciente.test'],
+        ])->map(fn (array $data) => User::factory()->create($data));
+
+        $treatments = [
+            'Profilaxis dental',
+            'Ortodoncia de revisión',
+            'Blanqueamiento láser',
+            'Colocación de carilla',
+        ];
+
+        $statuses = ['scheduled', 'confirmed', 'completed'];
+
+        $dentists->each(function (User $dentist) use ($patients, $treatments, $statuses): void {
+            $selectedPatients = $patients->random(2);
+
+            $meeting = Meeting::create([
+                'dentist_id' => $dentist->id,
+                'title' => 'Consulta dental de ' . $selectedPatients->first()->name,
+                'description' => 'Revisión integral y planificación de tratamiento dental.',
+                'treatment_type' => Arr::random($treatments),
+                'location' => 'Clínica Sonrisas Saludables, sala ' . random_int(1, 4),
+                'is_virtual' => false,
+                'scheduled_at' => Carbon::now()->addDays(random_int(1, 14))->setTime(9 + random_int(0, 4), 0),
+                'duration_minutes' => Arr::random([30, 45, 60]),
+                'status' => Arr::random($statuses),
+                'follow_up_required' => true,
+                'follow_up_notes' => null,
+                'reminders' => [
+                    'email' => Carbon::now()->addDays(1)->toDateTimeString(),
+                    'sms' => Carbon::now()->addDays(1)->setTime(8, 0)->toDateTimeString(),
+                ],
+            ]);
+
+            // Dentist as host participant
+            MeetingParticipant::create([
+                'meeting_id' => $meeting->id,
+                'user_id' => $dentist->id,
+                'full_name' => $dentist->name,
+                'email' => $dentist->email,
+                'phone_number' => fake()->phoneNumber(),
+                'role' => 'dentist',
+                'status' => 'confirmed',
+                'invited_at' => Carbon::now()->subDays(3),
+                'joined_at' => null,
+                'metadata' => ['lead' => true],
+            ]);
+
+            $selectedPatients->each(function (User $patient) use ($meeting): void {
+                MeetingParticipant::create([
+                    'meeting_id' => $meeting->id,
+                    'user_id' => $patient->id,
+                    'full_name' => $patient->name,
+                    'email' => $patient->email,
+                    'phone_number' => fake()->phoneNumber(),
+                    'role' => 'patient',
+                    'status' => Arr::random(['invited', 'confirmed']),
+                    'invited_at' => Carbon::now()->subDays(2),
+                    'metadata' => [
+                        'dental_history' => Arr::random([
+                            'Sensibilidad en premolares',
+                            'Uso de ortodoncia removible',
+                            'Tratamiento de caries en curso',
+                        ]),
+                    ],
+                ]);
+            });
+
+            MeetingNote::create([
+                'meeting_id' => $meeting->id,
+                'author_id' => $dentist->id,
+                'title' => 'Plan de higiene previo',
+                'category' => 'preparación',
+                'body' => 'Recomendar enjuague de clorhexidina dos veces al día previo a la sesión.',
+                'is_private' => false,
+                'attachments' => ['checklist' => 'https://demo.dental/notas/preparacion.pdf'],
+            ]);
+
+            MeetingNote::create([
+                'meeting_id' => $meeting->id,
+                'author_id' => $dentist->id,
+                'title' => 'Observaciones clínicas',
+                'category' => 'diagnóstico',
+                'body' => 'Recesión gingival leve en incisivos inferiores. Evaluar férula nocturna.',
+                'is_private' => true,
+                'attachments' => null,
+            ]);
+
+            MeetingAnalytic::create([
+                'meeting_id' => $meeting->id,
+                'total_duration_minutes' => $meeting->duration_minutes,
+                'total_participants' => $meeting->participants()->count(),
+                'unique_patients' => $meeting->participants()->where('role', 'patient')->count(),
+                'average_engagement' => Arr::random([82.5, 91.3, 88.0]),
+                'metrics' => [
+                    'questions_resolved' => random_int(3, 7),
+                    'satisfaction_score' => Arr::random([4.5, 4.8, 5.0]),
+                ],
+                'calculated_at' => Carbon::now(),
+            ]);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add meetings, meeting_participants, meeting_notes, and meeting_analytics tables with relationships and soft deletes
- implement Eloquent models for meetings, participants, notes, and analytics with scopes and casts
- seed demo dental data linking meetings, participants, notes, and analytics for testing

## Testing
- php artisan migrate:fresh --seed

------
https://chatgpt.com/codex/tasks/task_e_68d1c249f45c832cb6ff8b6be72ad8ed