### PR TITLE
feat: add DDU dashboard experience with livewire pages

### DIFF
--- a/app/Livewire/Dashboard/QuickActions.php
+++ b/app/Livewire/Dashboard/QuickActions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Livewire\Component;
+
+class QuickActions extends Component
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $actions = [
+        [
+            'label' => 'Programar nueva reunión',
+            'description' => 'Coordina agendas y envía invitaciones en segundos.',
+            'icon' => 'plus',
+            'href' => '/meetings',
+        ],
+        [
+            'label' => 'Registrar minuta',
+            'description' => 'Captura acuerdos clave y responsables.',
+            'icon' => 'document-text',
+            'href' => '/notes',
+        ],
+        [
+            'label' => 'Analítica DDU',
+            'description' => 'Revisa métricas de impacto y satisfacción.',
+            'icon' => 'chart-bar',
+            'href' => '/analytics',
+        ],
+    ];
+
+    public function render()
+    {
+        return view('livewire.dashboard.quick-actions');
+    }
+}

--- a/app/Livewire/Dashboard/RecentMeetings.php
+++ b/app/Livewire/Dashboard/RecentMeetings.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Carbon\Carbon;
+use Livewire\Component;
+
+class RecentMeetings extends Component
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $meetings = [];
+
+    public function mount(): void
+    {
+        $this->meetings = [
+            [
+                'title' => 'Kick-off Proyecto Atlas',
+                'owner' => 'Laura Martínez',
+                'time' => Carbon::parse('today 09:30')->isoFormat('DD MMM · HH:mm'),
+                'status' => 'Completada',
+            ],
+            [
+                'title' => 'Revisión Sprint 12',
+                'owner' => 'Equipo Producto',
+                'time' => Carbon::parse('today 13:00')->isoFormat('DD MMM · HH:mm'),
+                'status' => 'En curso',
+            ],
+            [
+                'title' => 'One-to-one Dirección',
+                'owner' => 'Andrés Duarte',
+                'time' => Carbon::parse('tomorrow 11:00')->isoFormat('DD MMM · HH:mm'),
+                'status' => 'Programada',
+            ],
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.recent-meetings');
+    }
+}

--- a/app/Livewire/Dashboard/StatsWidget.php
+++ b/app/Livewire/Dashboard/StatsWidget.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire\Dashboard;
+
+use Livewire\Component;
+
+class StatsWidget extends Component
+{
+    /**
+     * @var array<int, array<string, string|int>>
+     */
+    public array $metrics = [];
+
+    public function mount(): void
+    {
+        $this->metrics = [
+            [
+                'label' => 'Reuniones de hoy',
+                'value' => 4,
+                'trend' => '+12%',
+                'trend_label' => 'vs. ayer',
+                'icon' => 'calendar',
+            ],
+            [
+                'label' => 'Tasa de asistencia',
+                'value' => '92%',
+                'trend' => '+5%',
+                'trend_label' => 'últimos 7 días',
+                'icon' => 'check-circle',
+            ],
+            [
+                'label' => 'Notas registradas',
+                'value' => 28,
+                'trend' => '+18%',
+                'trend_label' => 'este mes',
+                'icon' => 'clipboard',
+            ],
+            [
+                'label' => 'Satisfacción promedio',
+                'value' => '4.6',
+                'trend' => '+0.3',
+                'trend_label' => 'en escala 1-5',
+                'icon' => 'sparkles',
+            ],
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.dashboard.stats-widget');
+    }
+}

--- a/app/Livewire/Meetings/MeetingForm.php
+++ b/app/Livewire/Meetings/MeetingForm.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Livewire\Meetings;
+
+use Livewire\Attributes\Rule;
+use Livewire\Component;
+
+class MeetingForm extends Component
+{
+    #[Rule('required|string|min:5')]
+    public string $title = '';
+
+    #[Rule('required|string')]
+    public string $date = '';
+
+    #[Rule('required|string')]
+    public string $time = '';
+
+    #[Rule('nullable|string')]
+    public string $participants = '';
+
+    #[Rule('nullable|string')]
+    public string $notes = '';
+
+    public bool $showConfirmation = false;
+
+    public function schedule(): void
+    {
+        $this->validate();
+
+        $this->reset(['title', 'date', 'time', 'participants', 'notes']);
+        $this->showConfirmation = true;
+
+        $this->dispatch('meeting-scheduled');
+    }
+
+    public function render()
+    {
+        return view('livewire.meetings.meeting-form');
+    }
+}

--- a/app/Livewire/Meetings/MeetingList.php
+++ b/app/Livewire/Meetings/MeetingList.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Meetings;
+
+use Livewire\Component;
+
+class MeetingList extends Component
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $meetings = [
+        [
+            'title' => 'Alineación Comercial',
+            'date' => 'Martes, 10:00',
+            'owner' => 'Mariana Ríos',
+            'status' => 'Confirmada',
+            'tags' => ['Estrategia', 'Ventas'],
+        ],
+        [
+            'title' => 'Diseño experiencia DDU',
+            'date' => 'Miércoles, 15:30',
+            'owner' => 'UX Guild',
+            'status' => 'Pendiente',
+            'tags' => ['Producto', 'Investigación'],
+        ],
+        [
+            'title' => 'Seguimiento proveedores',
+            'date' => 'Jueves, 09:00',
+            'owner' => 'Operaciones',
+            'status' => 'Reprogramada',
+            'tags' => ['Logística'],
+        ],
+    ];
+
+    public function render()
+    {
+        return view('livewire.meetings.meeting-list');
+    }
+}

--- a/app/Livewire/Pages/Analytics.php
+++ b/app/Livewire/Pages/Analytics.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Livewire\Pages;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class Analytics extends Component
+{
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.analytics')
+            ->title('Analítica DDU');
+    }
+}

--- a/app/Livewire/Pages/Dashboard.php
+++ b/app/Livewire/Pages/Dashboard.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Livewire\Pages;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class Dashboard extends Component
+{
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.dashboard')
+            ->title('Panel DDU');
+    }
+}

--- a/app/Livewire/Pages/Meetings.php
+++ b/app/Livewire/Pages/Meetings.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Livewire\Pages;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class Meetings extends Component
+{
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.meetings')
+            ->title('Reuniones DDU');
+    }
+}

--- a/app/Livewire/Pages/Notes.php
+++ b/app/Livewire/Pages/Notes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Livewire\Pages;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class Notes extends Component
+{
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.pages.notes')
+            ->title('Notas colaborativas');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,24 +13,55 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @livewireStyles
+
+        <style>[x-cloak] { display: none !important; }</style>
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100">
+    <body class="font-sans antialiased bg-slate-950 text-slate-100">
+        <div x-data="{}" class="flex min-h-screen bg-slate-950/95">
             <livewire:layout.navigation />
 
-            <!-- Page Heading -->
-            @if (isset($header))
-                <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                        {{ $header }}
+            <div class="flex flex-1 flex-col">
+                <header class="sticky top-0 z-30 border-b border-white/5 bg-slate-950/80 backdrop-blur">
+                    <div class="flex items-center justify-between px-6 py-4">
+                        <div class="flex items-center gap-3">
+                            <button class="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 p-2 text-slate-200 transition hover:border-primary-400/60 hover:text-primary-200 lg:hidden" @click="$dispatch('toggle-sidebar')">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                                </svg>
+                            </button>
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-300">Experiencia DDU</p>
+                                <p class="text-sm text-slate-400">Bienvenido, {{ auth()->user()->name ?? 'DDU Member' }}</p>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3">
+                            <div class="hidden items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold uppercase tracking-widest text-slate-300 md:flex">
+                                <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                                Sincronización activa
+                            </div>
+                            <div class="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-200">
+                                <div class="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-primary-500 to-sky-500 font-semibold text-slate-950">
+                                    {{ \Illuminate\Support\Str::upper(\Illuminate\Support\Str::substr(auth()->user()->name ?? 'DDU', 0, 2)) }}
+                                </div>
+                                <div class="hidden text-xs font-semibold uppercase tracking-widest text-slate-300 sm:block">
+                                    {{ auth()->user()->email ?? 'team@ddu' }}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </header>
-            @endif
 
-            <!-- Page Content -->
-            <main>
-                {{ $slot }}
-            </main>
+                <main class="flex-1 overflow-y-auto px-6 pb-12 pt-8">
+                    <div class="mx-auto w-full max-w-7xl">
+                        {{ $slot }}
+                    </div>
+                </main>
+            </div>
         </div>
+
+        @stack('modals')
+        @livewireScripts
     </body>
 </html>

--- a/resources/views/livewire/dashboard/quick-actions.blade.php
+++ b/resources/views/livewire/dashboard/quick-actions.blade.php
@@ -1,0 +1,26 @@
+<section class="rounded-3xl bg-gradient-to-br from-primary-500/20 via-sky-500/20 to-purple-500/10 p-6 ring-1 ring-white/10">
+    <header>
+        <h3 class="text-lg font-semibold text-white">Acciones rápidas</h3>
+        <p class="mt-1 text-sm text-slate-200/80">Impulsa la coordinación del equipo sin salir del panel.</p>
+    </header>
+
+    <div class="mt-6 grid gap-4 lg:grid-cols-3">
+        @foreach ($actions as $action)
+            <a href="{{ $action['href'] }}" wire:navigate class="group flex flex-col justify-between rounded-2xl border border-white/5 bg-slate-900/80 p-4 transition hover:border-primary-400/60 hover:bg-slate-900">
+                <div class="flex items-start gap-3">
+                    <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary-500/20 text-primary-200">
+                        @include('livewire.dashboard.svg-icon', ['name' => $action['icon'], 'classes' => 'h-5 w-5'])
+                    </div>
+                    <div>
+                        <p class="text-base font-semibold text-white">{{ $action['label'] }}</p>
+                        <p class="mt-1 text-sm text-slate-400">{{ $action['description'] }}</p>
+                    </div>
+                </div>
+                <span class="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-primary-200">
+                    Ir ahora
+                    @include('livewire.dashboard.svg-icon', ['name' => 'chevron-right', 'classes' => 'h-4 w-4 transition group-hover:translate-x-1'])
+                </span>
+            </a>
+        @endforeach
+    </div>
+</section>

--- a/resources/views/livewire/dashboard/recent-meetings.blade.php
+++ b/resources/views/livewire/dashboard/recent-meetings.blade.php
@@ -1,0 +1,34 @@
+<section class="rounded-3xl bg-slate-900/70 p-6 ring-1 ring-white/10">
+    <header class="flex items-center justify-between">
+        <div>
+            <h3 class="text-lg font-semibold text-white">Reuniones recientes</h3>
+            <p class="mt-1 text-sm text-slate-400">Seguimiento inmediato a las conversaciones clave de DDU.</p>
+        </div>
+        <a href="/meetings" wire:navigate class="inline-flex items-center gap-2 rounded-full bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-primary-200 transition hover:bg-primary-500/10">
+            Ver todas
+            @include('livewire.dashboard.svg-icon', ['name' => 'chevron-right', 'classes' => 'h-4 w-4'])
+        </a>
+    </header>
+
+    <ul class="mt-6 space-y-4">
+        @foreach ($meetings as $meeting)
+            <li class="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 transition hover:border-primary-400/60">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <p class="text-base font-medium text-white">{{ $meeting['title'] }}</p>
+                        <p class="text-sm text-slate-400">{{ $meeting['owner'] }}</p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-800/80 px-3 py-1 font-medium">
+                            @include('livewire.dashboard.svg-icon', ['name' => 'clock', 'classes' => 'h-4 w-4'])
+                            {{ $meeting['time'] }}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-primary-500/20 px-3 py-1 font-semibold text-primary-200">
+                            {{ $meeting['status'] }}
+                        </span>
+                    </div>
+                </div>
+            </li>
+        @endforeach
+    </ul>
+</section>

--- a/resources/views/livewire/dashboard/stats-widget.blade.php
+++ b/resources/views/livewire/dashboard/stats-widget.blade.php
@@ -1,0 +1,23 @@
+<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    @foreach ($metrics as $metric)
+        <article class="group relative overflow-hidden rounded-3xl bg-slate-900/70 p-5 ring-1 ring-white/10 transition hover:-translate-y-1 hover:ring-primary-400">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-sm font-medium text-slate-300">{{ $metric['label'] }}</p>
+                    <p class="mt-3 text-3xl font-semibold text-white">{{ $metric['value'] }}</p>
+                </div>
+                <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-500/20 text-primary-300">
+                    @include('livewire.dashboard.svg-icon', ['name' => $metric['icon']])
+                </div>
+            </div>
+            <dl class="mt-6 flex items-center gap-2 text-xs font-medium text-primary-200">
+                <dt class="rounded-full bg-primary-500/20 px-2 py-1 text-primary-100">{{ $metric['trend'] }}</dt>
+                <dd class="text-slate-400">{{ $metric['trend_label'] }}</dd>
+            </dl>
+            <div class="pointer-events-none absolute inset-0 opacity-0 mix-blend-screen transition duration-500 group-hover:opacity-100">
+                <div class="absolute -right-16 -top-16 h-32 w-32 rounded-full bg-primary-500/30 blur-3xl"></div>
+                <div class="absolute -bottom-20 -left-10 h-36 w-36 rounded-full bg-sky-400/20 blur-3xl"></div>
+            </div>
+        </article>
+    @endforeach
+</div>

--- a/resources/views/livewire/dashboard/svg-icon.blade.php
+++ b/resources/views/livewire/dashboard/svg-icon.blade.php
@@ -1,0 +1,74 @@
+@php
+    $classes = $classes ?? 'h-6 w-6';
+@endphp
+
+@switch($name)
+    @case('calendar')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 3v2m8-2v2M5 7h14M6 21h12a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H6a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1zm2-8h4" />
+        </svg>
+    @break
+
+    @case('check-circle')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12.75 11.25 15 15 9.75m4.5 2.25a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0z" />
+        </svg>
+    @break
+
+    @case('clipboard')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 4.5h6m-3 0A1.5 1.5 0 0 0 12 3a1.5 1.5 0 0 0-1.5 1.5H9A1.5 1.5 0 0 0 7.5 6v11.25A2.25 2.25 0 0 0 9.75 19.5h4.5A2.25 2.25 0 0 0 16.5 17.25V6A1.5 1.5 0 0 0 15 4.5h-1.5" />
+        </svg>
+    @break
+
+    @case('sparkles')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.813 15.904 9 18l-.812-2.096a3 3 0 0 0-1.892-1.892L4 13l2.296-.812a3 3 0 0 0 1.892-1.892L9 8l.813 2.296a3 3 0 0 0 1.892 1.892L14 13l-2.295.812a3 3 0 0 0-1.892 1.892zM15 5l.563 1.438a2 2 0 0 0 1.124 1.124L18 8l-1.313.438a2 2 0 0 0-1.124 1.124L15 11l-.563-1.438a2 2 0 0 0-1.124-1.124L12 8l1.313-.438a2 2 0 0 0 1.124-1.124z" />
+        </svg>
+    @break
+
+    @case('plus')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+        </svg>
+    @break
+
+    @case('document-text')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 7h6m-6 4h3m-6 7.5h9A2.25 2.25 0 0 0 17.25 16.5V8.621a2.25 2.25 0 0 0-.659-1.591l-2.97-2.97A2.25 2.25 0 0 0 12.03 3.4L6.75 3.375A2.25 2.25 0 0 0 4.5 5.625v10.875A2.25 2.25 0 0 0 6.75 18.75z" />
+        </svg>
+    @break
+
+    @case('chart-bar')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.75 21V7.5m5.25 13.5V3m5.25 18V10.5m5.25 10.5V13.5" />
+        </svg>
+    @break
+
+    @case('chevron-right')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m9 18 6-6-6-6" />
+        </svg>
+    @break
+
+    @case('clock')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6l3 3m5.25-3A8.25 8.25 0 1 1 3.75 12a8.25 8.25 0 0 1 16.5 0z" />
+        </svg>
+    @break
+
+    @case('user-group')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 20a6 6 0 0 0-12 0m12 0v-1a4 4 0 0 0-4-4h-4a4 4 0 0 0-4 4v1m12 0h1.5m-13.5 0H3m9-9a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" />
+        </svg>
+    @break
+
+    @case('bookmark')
+        <svg xmlns="http://www.w3.org/2000/svg" class="{{ $classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 21 12 17.25 6.75 21V5.25A2.25 2.25 0 0 1 9 3h6a2.25 2.25 0 0 1 2.25 2.25z" />
+        </svg>
+    @break
+
+    @default
+        <span class="sr-only">Icono</span>
+@endswitch

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -5,9 +5,6 @@ use Livewire\Volt\Component;
 
 new class extends Component
 {
-    /**
-     * Log the current user out of the application.
-     */
     public function logout(Logout $logout): void
     {
         $logout();
@@ -16,95 +13,105 @@ new class extends Component
     }
 }; ?>
 
-<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
-    <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-            <div class="flex">
-                <!-- Logo -->
-                <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}" wire:navigate>
-                        <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
-                    </a>
-                </div>
+@php
+    $links = [
+        [
+            'label' => 'Dashboard',
+            'route' => 'dashboard',
+            'icon' => 'sparkles',
+            'description' => 'Resumen ejecutivo del ecosistema DDU.',
+        ],
+        [
+            'label' => 'Reuniones',
+            'route' => 'meetings',
+            'icon' => 'calendar',
+            'description' => 'Agenda inteligente y coordinación.',
+        ],
+        [
+            'label' => 'Notas',
+            'route' => 'notes',
+            'icon' => 'document-text',
+            'description' => 'Conocimiento compartido y minutas.',
+        ],
+        [
+            'label' => 'Analítica',
+            'route' => 'analytics',
+            'icon' => 'chart-bar',
+            'description' => 'Indicadores y tendencias de impacto.',
+        ],
+    ];
+@endphp
 
-                <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
-                </div>
-            </div>
+<div x-data="{ open: false }" x-on:toggle-sidebar.window="open = !open" class="relative z-40">
+    <aside class="hidden w-72 flex-shrink-0 flex-col justify-between border-r border-white/5 bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900/80 px-6 py-8 text-slate-200 lg:flex">
+        <div>
+            <a href="{{ route('dashboard') }}" wire:navigate class="flex items-center gap-3">
+                <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500 to-sky-500 text-2xl font-semibold text-slate-950">DDU</span>
+                <span class="text-sm font-semibold uppercase tracking-[0.35em] text-primary-200">Experience Hub</span>
+            </a>
+            <p class="mt-6 text-xs text-slate-400">Orquesta tu experiencia DDU con foco humano + datos.</p>
 
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
-
-                            <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
+            <nav class="mt-8 space-y-2">
+                @foreach ($links as $link)
+                    @php $active = request()->routeIs($link['route']); @endphp
+                    <a href="{{ route($link['route']) }}" wire:navigate class="group block rounded-2xl border border-transparent px-4 py-3 transition {{ $active ? 'border-primary-400/60 bg-primary-500/10 text-white' : 'hover:border-primary-400/40 hover:bg-white/5' }}">
+                        <div class="flex items-center gap-3">
+                            <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/5 text-primary-200">
+                                @include('livewire.dashboard.svg-icon', ['name' => $link['icon']])
+                            </span>
+                            <div class="flex-1">
+                                <p class="text-sm font-semibold">{{ $link['label'] }}</p>
+                                <p class="text-xs text-slate-400">{{ $link['description'] }}</p>
                             </div>
-                        </button>
-                    </x-slot>
+                            @if ($active)
+                                <span class="h-2 w-2 rounded-full bg-primary-400"></span>
+                            @endif
+                        </div>
+                    </a>
+                @endforeach
+            </nav>
+        </div>
 
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile')" wire:navigate>
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <button wire:click="logout" class="w-full text-start">
-                            <x-dropdown-link>
-                                {{ __('Log Out') }}
-                            </x-dropdown-link>
-                        </button>
-                    </x-slot>
-                </x-dropdown>
+        <div class="space-y-4">
+            <div class="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
+                <p class="text-xs font-semibold uppercase tracking-widest text-primary-200">Estado</p>
+                <p class="mt-2 text-sm text-white">Última sincronización hace 3 min.</p>
+                <p class="mt-1 text-xs text-slate-400">Tu información está protegida con cifrado DDU Secure.</p>
             </div>
+            <button wire:click="logout" class="flex w-full items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold uppercase tracking-widest text-slate-200 transition hover:border-primary-400/60 hover:text-primary-200">
+                Cerrar sesión
+            </button>
+        </div>
+    </aside>
 
-            <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+    <div x-cloak x-show="open" class="fixed inset-0 flex lg:hidden">
+        <div class="absolute inset-0 bg-slate-950/80 backdrop-blur" @click="open = false"></div>
+        <aside class="relative z-10 flex w-72 flex-col justify-between border-r border-white/5 bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900/80 px-6 py-8 text-slate-200">
+            <div class="flex items-center justify-between">
+                <a href="{{ route('dashboard') }}" wire:navigate class="flex items-center gap-3">
+                    <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500 to-sky-500 text-2xl font-semibold text-slate-950">DDU</span>
+                    <span class="text-sm font-semibold uppercase tracking-[0.35em] text-primary-200">Experience Hub</span>
+                </a>
+                <button class="rounded-full border border-white/10 bg-white/5 p-2" @click="open = false">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6m0 12L6 6" />
                     </svg>
                 </button>
             </div>
-        </div>
+
+            <nav class="mt-8 space-y-2">
+                @foreach ($links as $link)
+                    @php $active = request()->routeIs($link['route']); @endphp
+                    <a href="{{ route($link['route']) }}" wire:navigate class="block rounded-2xl border border-transparent px-4 py-3 transition {{ $active ? 'border-primary-400/60 bg-primary-500/10 text-white' : 'hover:border-primary-400/40 hover:bg-white/5' }}" @click="open = false">
+                        <p class="text-sm font-semibold">{{ $link['label'] }}</p>
+                        <p class="text-xs text-slate-400">{{ $link['description'] }}</p>
+                    </a>
+                @endforeach
+            </nav>
+
+            <button wire:click="logout" class="flex w-full items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold uppercase tracking-widest text-slate-200 transition hover:border-primary-400/60 hover:text-primary-200">
+                Cerrar sesión
+            </button>
+        </aside>
     </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800" x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
-                <div class="font-medium text-sm text-gray-500">{{ auth()->user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile')" wire:navigate>
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
-                <button wire:click="logout" class="w-full text-start">
-                    <x-responsive-nav-link>
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
-                </button>
-            </div>
-        </div>
-    </div>
-</nav>
+</div>

--- a/resources/views/livewire/meetings/meeting-form.blade.php
+++ b/resources/views/livewire/meetings/meeting-form.blade.php
@@ -1,0 +1,59 @@
+<section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-900/80 to-slate-900/60 p-6 ring-1 ring-white/10">
+    <header>
+        <h2 class="text-xl font-semibold text-white">Programar reunión</h2>
+        <p class="mt-1 text-sm text-slate-400">Coordina y comunica la próxima conversación estratégica.</p>
+    </header>
+
+    @if ($showConfirmation)
+        <div x-data="{ visible: true }" x-show="visible" x-transition.opacity.duration.300ms x-init="setTimeout(() => visible = false, 4000)" class="mt-4 rounded-2xl border border-primary-400/40 bg-primary-500/20 px-4 py-3 text-sm text-primary-100">
+            ¡Reunión creada con éxito! El equipo recibirá la notificación en minutos.
+        </div>
+    @endif
+
+    <form wire:submit.prevent="schedule" class="mt-6 space-y-5">
+        <div>
+            <label for="title" class="text-sm font-semibold uppercase tracking-widest text-slate-300">Título</label>
+            <input id="title" type="text" wire:model.defer="title" class="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40" placeholder="Ej. Comité de innovación" />
+            @error('title')
+                <p class="mt-1 text-xs font-semibold text-rose-400">{{ $message }}</p>
+            @enderror
+        </div>
+        <div class="grid gap-4 md:grid-cols-2">
+            <div>
+                <label for="date" class="text-sm font-semibold uppercase tracking-widest text-slate-300">Fecha</label>
+                <input id="date" type="date" wire:model.defer="date" class="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40" />
+                @error('date')
+                    <p class="mt-1 text-xs font-semibold text-rose-400">{{ $message }}</p>
+                @enderror
+            </div>
+            <div>
+                <label for="time" class="text-sm font-semibold uppercase tracking-widest text-slate-300">Hora</label>
+                <input id="time" type="time" wire:model.defer="time" class="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40" />
+                @error('time')
+                    <p class="mt-1 text-xs font-semibold text-rose-400">{{ $message }}</p>
+                @enderror
+            </div>
+        </div>
+        <div>
+            <label for="participants" class="text-sm font-semibold uppercase tracking-widest text-slate-300">Participantes</label>
+            <input id="participants" type="text" wire:model.defer="participants" class="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40" placeholder="Añade correos separados por coma" />
+            @error('participants')
+                <p class="mt-1 text-xs font-semibold text-rose-400">{{ $message }}</p>
+            @enderror
+        </div>
+        <div>
+            <label for="notes" class="text-sm font-semibold uppercase tracking-widest text-slate-300">Notas</label>
+            <textarea id="notes" rows="3" wire:model.defer="notes" class="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40" placeholder="Comparte la intención y los resultados esperados."></textarea>
+            @error('notes')
+                <p class="mt-1 text-xs font-semibold text-rose-400">{{ $message }}</p>
+            @enderror
+        </div>
+        <div class="flex items-center justify-between">
+            <p class="text-xs text-slate-400">Tus invitados recibirán recordatorios automáticos DDU.</p>
+            <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-5 py-3 text-sm font-semibold uppercase tracking-widest text-slate-950 transition hover:bg-primary-400">
+                @include('livewire.dashboard.svg-icon', ['name' => 'plus', 'classes' => 'h-4 w-4'])
+                Programar
+            </button>
+        </div>
+    </form>
+</section>

--- a/resources/views/livewire/meetings/meeting-list.blade.php
+++ b/resources/views/livewire/meetings/meeting-list.blade.php
@@ -1,0 +1,39 @@
+<section class="rounded-3xl bg-slate-900/70 p-6 ring-1 ring-white/10">
+    <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <h2 class="text-xl font-semibold text-white">Agenda colaborativa</h2>
+            <p class="text-sm text-slate-400">Tu repositorio vivo de compromisos DDU.</p>
+        </div>
+        <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-primary-200 transition hover:border-primary-400/60">
+            Exportar agenda
+        </button>
+    </header>
+
+    <ul class="mt-6 space-y-4">
+        @foreach ($meetings as $meeting)
+            <li class="rounded-2xl border border-white/5 bg-white/5 p-4 transition hover:border-primary-400/60">
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <p class="text-lg font-semibold text-white">{{ $meeting['title'] }}</p>
+                        <p class="text-sm text-slate-400">Responsable: {{ $meeting['owner'] }}</p>
+                    </div>
+                    <div class="flex flex-col items-start gap-3 text-sm text-slate-200 md:items-end">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-800/80 px-3 py-1">
+                            @include('livewire.dashboard.svg-icon', ['name' => 'clock', 'classes' => 'h-4 w-4'])
+                            {{ $meeting['date'] }}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-primary-500/20 px-3 py-1 font-semibold text-primary-200">
+                            @include('livewire.dashboard.svg-icon', ['name' => 'bookmark', 'classes' => 'h-4 w-4'])
+                            {{ $meeting['status'] }}
+                        </span>
+                    </div>
+                </div>
+                <div class="mt-4 flex flex-wrap gap-2">
+                    @foreach ($meeting['tags'] as $tag)
+                        <span class="rounded-full bg-slate-800/80 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-300">{{ $tag }}</span>
+                    @endforeach
+                </div>
+            </li>
+        @endforeach
+    </ul>
+</section>

--- a/resources/views/livewire/pages/analytics.blade.php
+++ b/resources/views/livewire/pages/analytics.blade.php
@@ -1,0 +1,96 @@
+@php
+    $kpis = [
+        [
+            'label' => 'Impacto DDU',
+            'value' => '87%',
+            'description' => 'Porcentaje de equipos que reportan mejora en coordinación tras implementar el playbook DDU.',
+        ],
+        [
+            'label' => 'Tiempo promedio de respuesta',
+            'value' => '3.4 h',
+            'description' => 'Reducción del 25% frente a la línea base del trimestre anterior.',
+        ],
+        [
+            'label' => 'Engagement en notas',
+            'value' => '68 contribuciones',
+            'description' => 'Comentarios y coediciones realizadas en los últimos 14 días.',
+        ],
+    ];
+@endphp
+
+<div class="space-y-8">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900/80 p-8 text-white shadow-xl shadow-primary-950/40">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-300">DDU Analytics</p>
+                <h1 class="mt-2 text-3xl font-semibold sm:text-4xl">Inteligencia operativa</h1>
+                <p class="mt-3 max-w-3xl text-base text-slate-300">Descubre cómo las dinámicas de reunión y colaboración impactan la experiencia DDU en toda la organización.</p>
+            </div>
+            <div class="flex items-center gap-3">
+                <button class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-3 text-sm font-semibold uppercase tracking-widest text-white transition hover:border-primary-400/60">
+                    Descargar reporte mensual
+                </button>
+            </div>
+        </div>
+    </section>
+
+    <div class="grid gap-6 lg:grid-cols-3">
+        @foreach ($kpis as $kpi)
+            <article class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6 text-white transition hover:border-primary-400/60">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-200">{{ $kpi['label'] }}</p>
+                <p class="mt-4 text-4xl font-semibold">{{ $kpi['value'] }}</p>
+                <p class="mt-4 text-sm text-slate-300">{{ $kpi['description'] }}</p>
+                <div class="pointer-events-none absolute inset-0 opacity-0 mix-blend-screen transition duration-500 group-hover:opacity-100">
+                    <div class="absolute -right-12 top-10 h-40 w-40 rounded-full bg-primary-500/20 blur-3xl"></div>
+                    <div class="absolute -left-10 bottom-4 h-32 w-32 rounded-full bg-sky-500/20 blur-3xl"></div>
+                </div>
+            </article>
+        @endforeach
+    </div>
+
+    <section class="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <div class="rounded-3xl border border-white/5 bg-slate-900/70 p-6 text-white">
+            <header class="flex items-center justify-between">
+                <div>
+                    <h2 class="text-xl font-semibold">Tendencia semanal</h2>
+                    <p class="text-sm text-slate-400">Comparativa de reuniones realizadas vs. planificadas.</p>
+                </div>
+                <span class="rounded-full bg-primary-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-primary-200">+14% crecimiento</span>
+            </header>
+            <div class="mt-8 h-48 rounded-2xl bg-gradient-to-br from-primary-500/10 via-slate-900 to-slate-900/80">
+                <div class="flex h-full items-end justify-between gap-2 px-4 pb-4">
+                    @foreach (['L', 'M', 'X', 'J', 'V', 'S', 'D'] as $index => $day)
+                        @php
+                            $height = [40, 70, 55, 80, 65, 30, 45][$index];
+                        @endphp
+                        <div class="flex flex-col items-center gap-2 text-xs text-slate-400">
+                            <div class="flex h-32 w-8 items-end rounded-full bg-white/5">
+                                <div class="w-full rounded-full bg-gradient-to-t from-primary-500 to-sky-400" style="height: {{ $height }}%"></div>
+                            </div>
+                            <span>{{ $day }}</span>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+        <div class="rounded-3xl border border-white/5 bg-slate-900/70 p-6 text-white">
+            <h2 class="text-xl font-semibold">Top responsables</h2>
+            <ul class="mt-4 space-y-4">
+                @foreach ([
+                    ['name' => 'Laura Martínez', 'meetings' => 12],
+                    ['name' => 'Equipo Producto', 'meetings' => 9],
+                    ['name' => 'Customer Success', 'meetings' => 7],
+                    ['name' => 'Operaciones', 'meetings' => 6],
+                ] as $leader)
+                    <li class="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-200">
+                        <span>{{ $leader['name'] }}</span>
+                        <span class="inline-flex items-center gap-2 text-primary-200">
+                            @include('livewire.dashboard.svg-icon', ['name' => 'user-group', 'classes' => 'h-4 w-4'])
+                            {{ $leader['meetings'] }}
+                        </span>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    </section>
+</div>

--- a/resources/views/livewire/pages/dashboard.blade.php
+++ b/resources/views/livewire/pages/dashboard.blade.php
@@ -1,0 +1,31 @@
+<div class="space-y-8">
+    <section class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900/80 p-8 text-white shadow-xl shadow-primary-950/40">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-300">DDU Intelligence</p>
+                <h1 class="mt-2 text-3xl font-semibold sm:text-4xl">Panel de control</h1>
+                <p class="mt-3 max-w-3xl text-base text-slate-300">Visualiza el pulso operativo de tus reuniones, notas colaborativas y métricas de impacto en un mismo lugar.</p>
+            </div>
+            <div class="flex items-center gap-3">
+                <span class="rounded-full bg-primary-500/20 px-4 py-2 text-sm font-semibold text-primary-100">Semana 32</span>
+                <button class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-5 py-3 text-sm font-semibold uppercase tracking-widest text-slate-950 transition hover:bg-primary-400">
+                    Generar reporte
+                </button>
+            </div>
+        </div>
+        <div class="flex flex-wrap gap-3 text-xs text-slate-400">
+            <span class="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1">Ecosistema DDU</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1">Actualizado hace 5 min</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1">Modo colaborativo</span>
+        </div>
+    </section>
+
+    <livewire:dashboard.stats-widget />
+
+    <div class="grid gap-6 xl:grid-cols-3">
+        <div class="xl:col-span-2 space-y-6">
+            <livewire:dashboard.recent-meetings />
+        </div>
+        <livewire:dashboard.quick-actions />
+    </div>
+</div>

--- a/resources/views/livewire/pages/meetings.blade.php
+++ b/resources/views/livewire/pages/meetings.blade.php
@@ -1,0 +1,21 @@
+<div class="space-y-8">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900/80 p-8 text-white shadow-xl shadow-primary-950/40">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-300">DDU Meetings</p>
+                <h1 class="mt-2 text-3xl font-semibold sm:text-4xl">Centro de reuniones</h1>
+                <p class="mt-3 max-w-3xl text-base text-slate-300">Planifica, colabora y documenta cada reunión con la precisión y calidez de la identidad DDU.</p>
+            </div>
+            <div class="flex items-center gap-3">
+                <button class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-3 text-sm font-semibold uppercase tracking-widest text-white transition hover:border-primary-400/60">
+                    Importar desde calendario
+                </button>
+            </div>
+        </div>
+    </section>
+
+    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] xl:grid-cols-[420px_minmax(0,1fr)]">
+        <livewire:meetings.meeting-form />
+        <livewire:meetings.meeting-list />
+    </div>
+</div>

--- a/resources/views/livewire/pages/notes.blade.php
+++ b/resources/views/livewire/pages/notes.blade.php
@@ -1,0 +1,67 @@
+@php
+    $notes = [
+        [
+            'title' => 'Decisiones Comité DDU',
+            'summary' => 'Priorizar roadmap de automatización, habilitar pilotos en dos regiones y reforzar acompañamiento de onboarding.',
+            'author' => 'Carolina Ortiz',
+            'updated_at' => 'Hace 2 horas',
+            'tags' => ['Estrategia', 'Onboarding'],
+        ],
+        [
+            'title' => 'Minuta Kick-off Atlas',
+            'summary' => 'Objetivos compartidos, responsables asignados y KPI de éxito definidos con el equipo interdisciplinario.',
+            'author' => 'Equipo Proyecto Atlas',
+            'updated_at' => 'Hace 5 horas',
+            'tags' => ['Proyecto Atlas', 'KPIs'],
+        ],
+        [
+            'title' => 'Insights sesión clientes',
+            'summary' => 'Clientes valoran seguimiento post-reunión, solicitan más automatización y visualizaciones en tiempo real.',
+            'author' => 'Customer Success',
+            'updated_at' => 'Ayer',
+            'tags' => ['Clientes', 'Experiencia'],
+        ],
+    ];
+@endphp
+
+<div class="space-y-8">
+    <section class="rounded-3xl border border-white/5 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900/80 p-8 text-white shadow-xl shadow-primary-950/40">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-primary-300">DDU Notes</p>
+                <h1 class="mt-2 text-3xl font-semibold sm:text-4xl">Notas colaborativas</h1>
+                <p class="mt-3 max-w-3xl text-base text-slate-300">Convierte las conversaciones en conocimiento accionable y accesible para todo el equipo.</p>
+            </div>
+            <button class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-5 py-3 text-sm font-semibold uppercase tracking-widest text-slate-950 transition hover:bg-primary-400">
+                Nueva nota
+            </button>
+        </div>
+    </section>
+
+    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        @foreach ($notes as $note)
+            <article class="relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6 text-white transition hover:border-primary-400/60">
+                <div>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-primary-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-primary-200">{{ $note['updated_at'] }}</span>
+                    <h2 class="mt-4 text-2xl font-semibold">{{ $note['title'] }}</h2>
+                    <p class="mt-3 text-sm text-slate-300">{{ $note['summary'] }}</p>
+                </div>
+                <footer class="mt-6 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+                    <div class="inline-flex items-center gap-2">
+                        @include('livewire.dashboard.svg-icon', ['name' => 'user-group', 'classes' => 'h-5 w-5 text-primary-200'])
+                        {{ $note['author'] }}
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        @foreach ($note['tags'] as $tag)
+                            <span class="rounded-full bg-slate-900/80 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-slate-300">{{ $tag }}</span>
+                        @endforeach
+                    </div>
+                </footer>
+                <div class="pointer-events-none absolute inset-0 opacity-0 mix-blend-screen transition duration-500 hover:opacity-100">
+                    <div class="absolute -right-12 top-10 h-40 w-40 rounded-full bg-primary-500/20 blur-3xl"></div>
+                    <div class="absolute -left-10 bottom-4 h-32 w-32 rounded-full bg-sky-500/20 blur-3xl"></div>
+                </div>
+            </article>
+        @endforeach
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,15 +1,20 @@
 <?php
 
+use App\Livewire\Pages\Analytics;
+use App\Livewire\Pages\Dashboard;
+use App\Livewire\Pages\Meetings;
+use App\Livewire\Pages\Notes;
 use Illuminate\Support\Facades\Route;
 
-Route::view('/', 'welcome');
+Route::redirect('/', '/dashboard');
 
-Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified'])
-    ->name('dashboard');
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('dashboard', Dashboard::class)->name('dashboard');
+    Route::get('meetings', Meetings::class)->name('meetings');
+    Route::get('notes', Notes::class)->name('notes');
+    Route::get('analytics', Analytics::class)->name('analytics');
 
-Route::view('profile', 'profile')
-    ->middleware(['auth'])
-    ->name('profile');
+    Route::view('profile', 'profile')->name('profile');
+});
 
 require __DIR__.'/auth.php';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,21 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                primary: {
+                    50: '#eef4ff',
+                    100: '#dce8ff',
+                    200: '#bed2ff',
+                    300: '#95afff',
+                    400: '#6c83ff',
+                    500: '#5361ff',
+                    600: '#3d46db',
+                    700: '#3036af',
+                    800: '#2a338a',
+                    900: '#1e245f',
+                    950: '#12143c',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- redesign the authenticated layout and navigation to reflect the DDU visual identity
- add Livewire pages and widgets for dashboard, meetings, notes, and analytics flows
- extend the Tailwind palette and protect new routes for the DDU workspace

## Testing
- php artisan test *(fails: vendor directory not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c3d353c4832c91f11c87f1b5f28c